### PR TITLE
Add derived reflect combinators

### DIFF
--- a/src/Prelude.hs
+++ b/src/Prelude.hs
@@ -386,6 +386,11 @@ instance Display Char where
 instance Display Text where
   display = identity
 
+instance (Display a) => Display (Maybe a) where
+  display = \case
+    Nothing -> "Nothing"
+    Just v -> "Just " ++ display v
+
 instance (Display e, Display a) => Display (Either e a) where
   display = \case
     Left e -> "Error: " ++ display e


### PR DESCRIPTION
The following combinators can be created when a `reflect` is added to the language.

- `feedForward` is inspired by iTask's `>&>` combinator
- `feedSideways` is inspired by iTask's `>&^` combinator
- `feedBidirectionally` is inspired by iTask's `<&>` combinator

I think the names are terrible and too long.